### PR TITLE
Add windows support :)

### DIFF
--- a/memory_ipc.py
+++ b/memory_ipc.py
@@ -6,27 +6,46 @@ Direct read/write functions for specific memory blocks.
 
 import struct
 import time
-from typing import Optional, Union
-from macos_memory_reader import MacOSMemoryReader
+import sys  # Added: To check the operating system
+from typing import Optional
+
+# --- MODIFIED: Platform-specific imports ---
+# This code now dynamically chooses the correct reader based on the OS.
+# It assumes you have a 'windows_memory_reader.py' file with a 'WindowsMemoryReader' class.
+if sys.platform == 'darwin':
+    from macos_memory_reader import MacOSMemoryReader
+elif sys.platform == 'win32':
+    from windows_memory_reader import WindowsMemoryReader
+
+
+# -------------------------------------------
 
 
 class MemoryIPC:
     """Simple interface for reading/writing GameCube memory blocks."""
-    
+
     def __init__(self):
-        self.reader = MacOSMemoryReader()
+        # --- MODIFIED: Select reader based on OS ---
+        if sys.platform == 'darwin':
+            self.reader = MacOSMemoryReader()
+        elif sys.platform == 'win32':
+            self.reader = WindowsMemoryReader()
+        else:
+            raise NotImplementedError(f"Operating system '{sys.platform}' is not supported.")
+        # -------------------------------------------
+
         self.connected = False
         self.gamecube_base = None
-        
+
     def connect(self) -> bool:
         """Connect to Dolphin and find GameCube memory."""
         if not self.reader.connect_to_process():
             return False
-            
+
         # Find the main GameCube memory region
         regions = self.reader.get_memory_regions()
         for addr, size, prot in regions:
-            if size >= 0x1800000 and 'rw' in prot:  # At least 24MB
+            if size >= 0x1800000 and ('rw' in prot or prot == 'READWRITE'):  # At least 24MB, handle win32 prot
                 # Check if this contains game data
                 test_data = self.reader.read_memory(addr, 16)
                 if test_data and b'GAFE' in test_data:  # Animal Crossing
@@ -34,77 +53,77 @@ class MemoryIPC:
                     self.connected = True
                     print(f"✅ Connected! GameCube memory at 0x{addr:016X}")
                     return True
-        
+
         print("❌ Could not find GameCube memory")
         return False
-    
-    def _gc_to_real_addr(self, gc_address: int) -> int:
+
+    def _gc_to_real_addr(self, gc_address: int) -> Optional[int]:
         """Convert GameCube virtual address to real process address."""
         if not self.connected or not self.gamecube_base:
             return None
-        
+
         # GameCube main memory: 0x80000000-0x81800000 maps to base+offset
         if 0x80000000 <= gc_address < 0x81800000:
             offset = gc_address - 0x80000000
             return self.gamecube_base + offset
-        
+
         return None
-    
+
     def read_memory(self, gc_address: int, size: int) -> Optional[bytes]:
         """
         Read a block of memory from GameCube address.
-        
+
         Args:
             gc_address: GameCube virtual address (e.g., 0x80003000)
             size: Number of bytes to read
-            
+
         Returns:
             bytes data or None if failed
         """
         real_addr = self._gc_to_real_addr(gc_address)
         if real_addr is None:
             return None
-        
+
         return self.reader.read_memory(real_addr, size)
-    
+
     def write_memory(self, gc_address: int, data: bytes) -> bool:
         """
         Write a block of memory to GameCube address.
-        
+
         Args:
             gc_address: GameCube virtual address (e.g., 0x80003000)
             data: bytes to write
-            
+
         Returns:
             True if successful, False otherwise
         """
         real_addr = self._gc_to_real_addr(gc_address)
         if real_addr is None:
             return False
-        
+
         return self.reader.write_memory(real_addr, data)
-    
+
     def read_word(self, gc_address: int) -> Optional[int]:
         """Read a 32-bit word (4 bytes) as big-endian integer."""
         data = self.read_memory(gc_address, 4)
         if data and len(data) == 4:
             return struct.unpack('>I', data)[0]
         return None
-    
+
     def read_float(self, gc_address: int) -> Optional[float]:
         """Read a 32-bit float as big-endian."""
         data = self.read_memory(gc_address, 4)
         if data and len(data) == 4:
             return struct.unpack('>f', data)[0]
         return None
-    
+
     def read_byte(self, gc_address: int) -> Optional[int]:
         """Read a single byte."""
         data = self.read_memory(gc_address, 1)
         if data:
             return data[0]
         return None
-    
+
     def read_string(self, gc_address: int, max_length: int = 256) -> Optional[str]:
         """Read a null-terminated string."""
         data = self.read_memory(gc_address, max_length)
@@ -114,15 +133,16 @@ class MemoryIPC:
             if null_pos >= 0:
                 data = data[:null_pos]
             try:
+                # Animal Crossing uses a custom encoding, but ascii is fine for simple text
                 return data.decode('ascii', errors='ignore')
             except UnicodeDecodeError:
                 return None
         return None
-    
+
     def monitor_changes(self, gc_address: int, size: int, interval: float = 0.1) -> None:
         """
         Monitor a memory block for changes.
-        
+
         Args:
             gc_address: GameCube address to monitor
             size: Size of block to monitor
@@ -130,27 +150,27 @@ class MemoryIPC:
         """
         print(f"🎮 Monitoring 0x{gc_address:08X} ({size} bytes)")
         print("Press Ctrl+C to stop")
-        
+
         last_data = None
-        
+
         try:
             while True:
                 current_data = self.read_memory(gc_address, size)
-                
+
                 if current_data != last_data and current_data is not None:
                     timestamp = time.strftime("%H:%M:%S")
                     print(f"[{timestamp}] 0x{gc_address:08X}: {current_data.hex()}")
                     last_data = current_data
-                
+
                 time.sleep(interval)
-                
+
         except KeyboardInterrupt:
             print("\n⏹️ Monitoring stopped")
-    
+
     def dump_memory(self, gc_address: int, size: int, format: str = "hex") -> None:
         """
         Dump memory in various formats.
-        
+
         Args:
             gc_address: GameCube address
             size: Number of bytes
@@ -160,36 +180,36 @@ class MemoryIPC:
         if not data:
             print(f"❌ Could not read from 0x{gc_address:08X}")
             return
-        
+
         print(f"📖 Memory dump: 0x{gc_address:08X} ({len(data)} bytes)")
-        
+
         if format == "hex":
             # Hex dump with ASCII
             for i in range(0, len(data), 16):
-                chunk = data[i:i+16]
+                chunk = data[i:i + 16]
                 hex_str = ' '.join(f'{b:02X}' for b in chunk)
                 ascii_str = ''.join(chr(b) if 32 <= b <= 126 else '.' for b in chunk)
-                print(f"  {gc_address + i:08X}: {hex_str:<48} {ascii_str}")
-        
+                print(f"  {self._gc_to_real_addr(gc_address) + i:08X}: {hex_str:<48} {ascii_str}")
+
         elif format == "ascii":
             # ASCII dump
             ascii_str = ''.join(chr(b) if 32 <= b <= 126 else '.' for b in data)
             print(f"  ASCII: {ascii_str}")
-        
+
         elif format == "words":
             # 32-bit words
             for i in range(0, len(data), 4):
                 if i + 4 <= len(data):
-                    word = struct.unpack('>I', data[i:i+4])[0]
+                    word = struct.unpack('>I', data[i:i + 4])[0]
                     print(f"  {gc_address + i:08X}: 0x{word:08X} ({word})")
-        
+
         elif format == "floats":
             # 32-bit floats
             for i in range(0, len(data), 4):
                 if i + 4 <= len(data):
-                    float_val = struct.unpack('>f', data[i:i+4])[0]
+                    float_val = struct.unpack('>f', data[i:i + 4])[0]
                     print(f"  {gc_address + i:08X}: {float_val:.6f}")
-    
+
     def disconnect(self):
         """Disconnect from Dolphin."""
         if self.reader:
@@ -200,11 +220,13 @@ class MemoryIPC:
 # Convenience functions for quick access
 _ipc = None
 
+
 def connect() -> bool:
     """Initialize connection to Dolphin."""
     global _ipc
     _ipc = MemoryIPC()
     return _ipc.connect()
+
 
 def read_memory(gc_address: int, size: int) -> Optional[bytes]:
     """Read memory block."""
@@ -213,12 +235,14 @@ def read_memory(gc_address: int, size: int) -> Optional[bytes]:
         return None
     return _ipc.read_memory(gc_address, size)
 
+
 def read_word(gc_address: int) -> Optional[int]:
     """Read 32-bit word."""
     if not _ipc or not _ipc.connected:
         print("❌ Not connected. Call connect() first.")
         return None
     return _ipc.read_word(gc_address)
+
 
 def read_float(gc_address: int) -> Optional[float]:
     """Read 32-bit float."""
@@ -227,12 +251,14 @@ def read_float(gc_address: int) -> Optional[float]:
         return None
     return _ipc.read_float(gc_address)
 
+
 def read_byte(gc_address: int) -> Optional[int]:
     """Read single byte."""
     if not _ipc or not _ipc.connected:
         print("❌ Not connected. Call connect() first.")
         return None
     return _ipc.read_byte(gc_address)
+
 
 def write_memory(gc_address: int, data: bytes) -> bool:
     """Write memory block."""
@@ -241,12 +267,14 @@ def write_memory(gc_address: int, data: bytes) -> bool:
         return False
     return _ipc.write_memory(gc_address, data)
 
+
 def monitor(gc_address: int, size: int = 4):
     """Monitor memory for changes."""
     if not _ipc or not _ipc.connected:
         print("❌ Not connected. Call connect() first.")
         return
     _ipc.monitor_changes(gc_address, size)
+
 
 def dump(gc_address: int, size: int = 64, format: str = "hex"):
     """Dump memory in various formats."""
@@ -260,26 +288,26 @@ def main():
     """Example usage."""
     print("🎮 Memory IPC Example Usage")
     print()
-    
+
     # Connect to Dolphin
     if not connect():
         print("Failed to connect to Dolphin")
         return
-    
+
     # Example: Read some common Animal Crossing addresses
     print("📖 Reading common game memory locations:")
-    
+
     # Game ID
     game_id = read_memory(0x80000000, 8)
     if game_id:
-        print(f"Game ID: {game_id}")
-    
+        print(f"Game ID: {game_id.decode('ascii', errors='ignore')}")
+
     # Some data areas
     for addr in [0x80003000, 0x80004000, 0x80100000]:
         word = read_word(addr)
         if word is not None:
             print(f"0x{addr:08X}: 0x{word:08X}")
-    
+
     print()
     print("🔧 Try these functions:")
     print("  read_memory(0x80003000, 16)  # Read 16 bytes")

--- a/memory_ipc.py
+++ b/memory_ipc.py
@@ -7,7 +7,7 @@ Direct read/write functions for specific memory blocks.
 import struct
 import time
 import sys  # Added: To check the operating system
-from typing import Optional
+from typing import Optional, Union
 
 # --- MODIFIED: Platform-specific imports ---
 # This code now dynamically chooses the correct reader based on the OS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 PyGetWindow==0.0.9
 PyMsgBox==1.0.9
-pyobjc-core==11.1
-pyobjc-framework-Cocoa==11.1
-pyobjc-framework-Quartz==11.1
+pyobjc-core==11.1; sys_platform == 'darwin' #this is only needed for macos, windows does not need pyobjc
+pyobjc-framework-Cocoa==11.1; sys_platform == 'darwin'
+pyobjc-framework-Quartz==11.1; sys_platform == 'darwin'
 pyperclip==1.9.0
 PyRect==0.2.0
 PyScreeze==1.0.1

--- a/windows_memory_reader.py
+++ b/windows_memory_reader.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Windows Memory Reader for Dolphin
+Custom implementation to read memory from the Dolphin process on Windows using the Win32 API.
+"""
+
+import ctypes
+from ctypes import wintypes
+import struct
+from typing import Optional, List, Tuple
+import psutil
+
+
+# --- Define necessary Windows structures and constants ---
+
+# Define the MEMORY_BASIC_INFORMATION structure
+class MEMORY_BASIC_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ('BaseAddress', wintypes.LPVOID),
+        ('AllocationBase', wintypes.LPVOID),
+        ('AllocationProtect', wintypes.DWORD),
+        ('RegionSize', ctypes.c_size_t),
+        ('State', wintypes.DWORD),
+        ('Protect', wintypes.DWORD),
+        ('Type', wintypes.DWORD),
+    ]
+
+
+# Process access rights constants
+PROCESS_QUERY_INFORMATION = 0x0400
+PROCESS_VM_READ = 0x0010
+PROCESS_VM_WRITE = 0x0020
+PROCESS_VM_OPERATION = 0x0008
+
+# Memory state constants
+MEM_COMMIT = 0x1000
+MEM_RESERVE = 0x2000
+MEM_FREE = 0x10000
+
+# Memory protection constants
+PAGE_READWRITE = 0x04
+PAGE_READONLY = 0x02
+PAGE_EXECUTE_READWRITE = 0x40
+PAGE_EXECUTE_READ = 0x20
+
+
+class WindowsMemoryReader:
+    """Direct memory reader for Windows processes using the Win32 API."""
+
+    def __init__(self):
+        self.pid = None
+        self.process_handle = None
+        self.is_connected = False
+
+        # Load kernel32.dll
+        self.kernel32 = ctypes.windll.kernel32
+
+        # Set up function prototypes for Win32 API calls
+        self._setup_function_prototypes()
+
+    def _setup_function_prototypes(self):
+        """Set up ctypes function prototypes for Win32 API calls."""
+
+        # OpenProcess
+        self.kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        self.kernel32.OpenProcess.restype = wintypes.HANDLE
+
+        # ReadProcessMemory
+        self.kernel32.ReadProcessMemory.argtypes = [wintypes.HANDLE, wintypes.LPCVOID, wintypes.LPVOID, ctypes.c_size_t,
+                                                    ctypes.POINTER(ctypes.c_size_t)]
+        self.kernel32.ReadProcessMemory.restype = wintypes.BOOL
+
+        # WriteProcessMemory
+        self.kernel32.WriteProcessMemory.argtypes = [wintypes.HANDLE, wintypes.LPVOID, wintypes.LPCVOID,
+                                                     ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t)]
+        self.kernel32.WriteProcessMemory.restype = wintypes.BOOL
+
+        # VirtualQueryEx
+        self.kernel32.VirtualQueryEx.argtypes = [wintypes.HANDLE, wintypes.LPCVOID,
+                                                 ctypes.POINTER(MEMORY_BASIC_INFORMATION), ctypes.c_size_t]
+        self.kernel32.VirtualQueryEx.restype = ctypes.c_size_t
+
+        # CloseHandle
+        self.kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        self.kernel32.CloseHandle.restype = wintypes.BOOL
+
+    def find_dolphin_process(self) -> Optional[int]:
+        """Find the running Dolphin process."""
+        try:
+            # Look for Dolphin.exe or a process named Dolphin
+            for proc in psutil.process_iter(['pid', 'name']):
+                if 'Dolphin' in proc.info['name']:
+                    return proc.info['pid']
+            return None
+        except Exception as e:
+            print(f"Error finding Dolphin process: {e}")
+            return None
+
+    def connect_to_process(self, pid: int = None) -> bool:
+        """Connect to the Dolphin process."""
+        if pid is None:
+            pid = self.find_dolphin_process()
+            if pid is None:
+                print("❌ Could not find Dolphin process")
+                return False
+
+        self.pid = pid
+        print(f"🔍 Found Dolphin process: PID {self.pid}")
+
+        # Define the access rights we need
+        access_rights = (PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION)
+
+        # Get a handle to the process
+        handle = self.kernel32.OpenProcess(access_rights, False, self.pid)
+
+        if not handle:
+            error_code = self.kernel32.GetLastError()
+            print(f"❌ Failed to get handle for PID {self.pid} (Error code: {error_code})")
+            print("   This usually means you need to run the script as an Administrator.")
+            return False
+
+        self.process_handle = handle
+        self.is_connected = True
+        print(f"✅ Successfully connected to Dolphin process!")
+        return True
+
+    def read_memory(self, address: int, size: int) -> Optional[bytes]:
+        """Read memory from the connected process."""
+        if not self.is_connected:
+            print("❌ Not connected to process")
+            return None
+
+        buffer = ctypes.create_string_buffer(size)
+        bytes_read = ctypes.c_size_t(0)
+
+        result = self.kernel32.ReadProcessMemory(
+            self.process_handle,
+            address,
+            buffer,
+            size,
+            ctypes.byref(bytes_read)
+        )
+
+        if not result:
+            # Uncomment for deep debugging:
+            # error_code = self.kernel32.GetLastError()
+            # print(f"❌ Failed to read memory at 0x{address:016X} (Error code: {error_code})")
+            return None
+
+        return buffer.raw[:bytes_read.value]
+
+    def write_memory(self, address: int, data: bytes) -> bool:
+        """Write memory to the connected process."""
+        if not self.is_connected:
+            print("❌ Not connected to process")
+            return False
+
+        size = len(data)
+        buffer = ctypes.create_string_buffer(data)
+        bytes_written = ctypes.c_size_t(0)
+
+        result = self.kernel32.WriteProcessMemory(
+            self.process_handle,
+            address,
+            buffer,
+            size,
+            ctypes.byref(bytes_written)
+        )
+
+        if not result or bytes_written.value != size:
+            error_code = self.kernel32.GetLastError()
+            print(f"❌ Failed to write memory at 0x{address:016X} (Error code: {error_code})")
+            return False
+
+        return True
+
+    def get_memory_regions(self) -> List[Tuple[int, int, str]]:
+        """Get list of memory regions in the target process."""
+        if not self.is_connected:
+            return []
+
+        regions = []
+        current_address = 0
+
+        while True:
+            mbi = MEMORY_BASIC_INFORMATION()
+            result = self.kernel32.VirtualQueryEx(
+                self.process_handle,
+                current_address,
+                ctypes.byref(mbi),
+                ctypes.sizeof(mbi)
+            )
+
+            if result == 0:
+                break  # Reached end of address space
+
+            # We are interested in committed memory that is not free
+            if mbi.State == MEM_COMMIT:
+                addr = mbi.BaseAddress
+                size = mbi.RegionSize
+                prot = self._get_protection_string(mbi.Protect)
+                regions.append((addr, size, prot))
+
+            # --- THIS IS THE FIX ---
+            # Handle case where BaseAddress can be None for address 0
+            base_addr = mbi.BaseAddress if mbi.BaseAddress is not None else 0
+            current_address = base_addr + mbi.RegionSize
+            # ---------------------
+
+        return regions
+
+    def _get_protection_string(self, protection_flags: int) -> str:
+        """Convert Windows memory protection flags to a 'rwx' string."""
+        prot = ['-', '-', '-']
+        if protection_flags & (PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE):
+            prot[0] = 'r'
+        if protection_flags & (PAGE_READWRITE | PAGE_EXECUTE_READWRITE):
+            prot[1] = 'w'
+        if protection_flags & (PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE):
+            prot[2] = 'x'
+        return "".join(prot)
+
+    def disconnect(self):
+        """Disconnect from the process by closing the handle."""
+        if self.process_handle:
+            self.kernel32.CloseHandle(self.process_handle)
+        self.is_connected = False
+        self.process_handle = None
+        self.pid = None
+
+    # --- Helper methods (identical to macOS version, provided for completeness) ---
+
+    def read_byte(self, address: int) -> Optional[int]:
+        data = self.read_memory(address, 1)
+        if data:
+            return data[0]
+        return None
+
+    def read_word(self, address: int) -> Optional[int]:
+        data = self.read_memory(address, 4)
+        if data and len(data) == 4:
+            return struct.unpack('>I', data)[0]
+        return None
+
+    def read_float(self, address: int) -> Optional[float]:
+        data = self.read_memory(address, 4)
+        if data and len(data) == 4:
+            return struct.unpack('>f', data)[0]
+        return None
+
+
+def main():
+    """Test the Windows memory reader."""
+    print("💻 Windows Dolphin Memory Reader")
+    print("Attempting to connect to Dolphin...")
+
+    reader = WindowsMemoryReader()
+
+    if not reader.connect_to_process():
+        print("\n💡 Troubleshooting:")
+        print("   1. Make sure Dolphin is running.")
+        print("   2. Right-click your terminal (CMD/PowerShell) and 'Run as Administrator'.")
+        return
+
+    print("\n📋 Memory regions (looking for large RW regions that could be GameCube memory):")
+    regions = reader.get_memory_regions()
+
+    # Look for interesting regions (large, readable/writable)
+    interesting_regions = []
+    for addr, size, prot in regions:
+        if size >= 0x1800000 and 'rw' in prot:  # At least 24MB and readable/writable
+            interesting_regions.append((addr, size, prot))
+
+    print(f"Found {len(interesting_regions)} potential GameCube memory regions:")
+    for addr, size, prot in interesting_regions:
+        print(f"   0x{addr:016X} ({prot}) Size: {size // 1024 // 1024}MB")
+        # Let's read the first few bytes to confirm
+        test_data = reader.read_memory(addr, 16)
+        if test_data:
+            print(f"     -> First 16 bytes: {test_data.hex()}")
+
+    reader.disconnect()
+    print("\n✅ Test complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The project had two main issues preventing it from running on Windows:

1.  Hardcoded macOS Dependencies: The requirements.txt file explicitly listed pyobjc-core and other pyobjc-* packages, which can only be installed on macOS. This caused pip install to fail immediately for any non-macOS system.
3.  macOS-Specific Runtime Code: The memory reading logic was hardcoded to use MacOSMemoryReader, which relies on macOS-native mach system calls. This would cause a runtime crash on Windows even if the dependencies were manually installed.

**Key Changes**

    requirements.txt: Added sys_platform == 'darwin' markers to all pyobjc packages.

    memory_ipc.py: Modified the MemoryIPC.__init__ method to dynamically select the correct memory reader based on the OS.

    windows_memory_reader.py (New File): Added a complete memory reader implementation for Windows using ctypes and the Win32 API.

    Bug Fix: Corrected a TypeError in windows_memory_reader.py that occurred when iterating memory regions starting at address 0, where BaseAddress could be None.

tested dolphin version - 2506a

There is a chance this introduces issues on darwin/macos, but it should not. Reviewer should confirm this before approval. 