### PR TITLE
Add OpenAI Support

### DIFF
--- a/dialogue_prompt.py
+++ b/dialogue_prompt.py
@@ -571,13 +571,13 @@ def get_model_provider(model: Optional[str] = None):
         raise RuntimeError("Must define either GOOGLE_API_KEY or OPENAI_API_KEY in environment")
 
 
-def call_llm(prompt: str, model: Optional[str] = None, image_paths: Optional[List[str]] = None) -> str:
+def call_llm(prompt: str, model: Optional[str] = None, temperature: float = 1.0, max_tokens: int = 512, image_paths: Optional[List[str]] = None) -> str:
     model_provider = get_model_provider(model)
 
     if model_provider == "google":
-        return call_llm_gemini(prompt=prompt, model=model, image_paths=image_paths)
+        return call_llm_gemini(prompt=prompt, model=model, temperature=temperature, image_paths=image_paths)
     elif model_provider == "openai":
-        return call_llm_openai(prompt=prompt, model=model, image_paths=image_paths)
+        return call_llm_openai(prompt=prompt, model=model, temperature=temperature, image_paths=image_paths)
     else:
         raise ValueError("Invalid model provider")
 

--- a/dialogue_prompt.py
+++ b/dialogue_prompt.py
@@ -451,6 +451,18 @@ def format_spotlight_prompt(
     return prompt
 
 
+def encode_image(path: str) -> tuple[str, str]:
+    """
+    Given a path to an image, return a tuple of the base64 encoded string and the mime
+    type of the image.
+    """
+    with open(path, "rb") as f:
+        img_bytes = f.read()
+    base64_image = base64.b64encode(img_bytes).decode("utf-8")
+    mime = "image/png" if path.lower().endswith(".png") else "image/jpeg"
+    return base64_image, mime
+
+
 def call_llm_gemini(prompt: str, model: Optional[str] = None, temperature: float = 1.0, max_tokens: int = 512, image_paths: Optional[List[str]] = None) -> str:
     api_key = os.environ.get("GOOGLE_API_KEY")
     if not api_key:
@@ -467,13 +479,11 @@ def call_llm_gemini(prompt: str, model: Optional[str] = None, temperature: float
         inline_parts: List[Any] = []
         for path in image_paths:
             try:
-                with open(path, "rb") as f:
-                    img_bytes = f.read()
-                mime = "image/png" if path.lower().endswith(".png") else "image/jpeg"
+                base64_image, mime = encode_image(path)
                 inline_parts.append({
                     "inline_data": {
                         "mime_type": mime,
-                        "data": base64.b64encode(img_bytes).decode("utf-8"),
+                        "data": base64_image,
                     }
                 })
             except Exception:
@@ -490,6 +500,55 @@ def call_llm_gemini(prompt: str, model: Optional[str] = None, temperature: float
     )
 
     return getattr(resp, "text", "") or ""
+
+
+def call_llm_openai(prompt: str, model: Optional[str] = None, temperature: float = 1.0, max_tokens: int = 512, image_paths: Optional[List[str]] = None) -> str:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set in environment")
+    try:
+        from openai import OpenAI
+    except Exception as e:
+        raise RuntimeError("openai package not installed. Please install it to call OpenAI API.") from e
+
+    client = OpenAI(api_key=api_key)
+    model = model or os.environ.get("OPENAI_MODEL", "gpt-5-nano")
+
+    contents = [
+        { 
+            "type": "input_text",
+            "text": prompt
+        }
+    ]
+
+    if image_paths:
+        input_image_contents: List[dict[str, str]] = []
+        for path in image_paths:
+            try:
+                base64_image, mime = encode_image(path)
+                input_image_contents.append({
+                    "type": "input_image",
+                    "image_url": f"data:{mime};base64,{base64_image}",
+                })
+            except Exception:
+                continue
+        if input_image_contents:
+            contents += input_image_contents
+
+
+    resp = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role":"user",
+                "content": contents
+            }
+        ],
+        reasoning={ "effort": "minimal" },
+        temperature=temperature,
+    )
+
+    return resp.output_text
 
 
 def _format_control_code_decorator_prompt(raw_lines: str) -> str:


### PR DESCRIPTION
Closes https://github.com/vuciv/animal-crossing-llm-mod/issues/8

### Summary

This PR adds support for OpenAI models for dialogue generation.

The default OpenAI model is GPT-5 Nano set to "minimal" reasoning. A different OpenAI model can be specified with the `OPENAI_MODEL` environment variable. A separate decorator model can be set with  `OPENAI_DECORATOR_MODEL` environment variable.

### How The Model Provider is Selected
- If running `dialogue_prompt` through the CLI with the `--model` flag, then use that model's provider
- Otherwise, if the environment variable `MODEL_PROVIDER` is specified, use that model provider
- Otherwise, if an OpenAI API key is the only API key provided, then use OpenAI
- Otherwise use Google

### Model Performance/Characteristics
GPT-5 Nano generates responses slower than the Gemini Flash-Lite models. If generation time is your most important metric than I would recommend sticking with those.

In my brief testing GPT-5 Nano also tended to place expressions only at the end of lines of text (i.e. before `<Press A><Clear Text>`) It also generally shied away from using colored text.